### PR TITLE
Add Mahindra cars data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "fzaninotto/faker": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=5.7 <8"
+        "phpunit/phpunit": "^7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "fzaninotto/faker": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": ">=5.7 <8"
     },
     "autoload": {
         "psr-4": {

--- a/src/CarData.php
+++ b/src/CarData.php
@@ -317,6 +317,9 @@ class CarData
         'Marshell' => array(
             'DN', 'DG-C2'
         ),
+        'Mahindra' => array(
+            'Alturas G4', 'Bolero', 'KUV100', 'KUV100 NXT', 'Marazzo', 'Scorpio', 'Scorpio Getaway', 'TUV300', 'TUV300 PLUS', 'Thar', 'Verito', 'Verito Vibe CS', 'XUV500', 'e20 NXT', 'e2o PLUS', 'eKUV100', 'XUV300'
+        ),
         'Maruti' => array(
             '1000', '800', 'Alto', 'Baleno', 'Esteem', 'Gypsy', 'Omni', 'Versa', 'Wagon R', 'Zen', 'Suzuki'
         ),

--- a/tests/Faker/FakecarTest.php
+++ b/tests/Faker/FakecarTest.php
@@ -15,7 +15,7 @@ class FakecarTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = Factory::create();
         $faker->addProvider(new Fakecar($faker));

--- a/tests/Faker/FakecarTest.php
+++ b/tests/Faker/FakecarTest.php
@@ -15,7 +15,7 @@ class FakecarTest extends TestCase
      */
     private $faker;
 
-    public function setUp(): void
+    public function setUp()
     {
         $faker = Factory::create();
         $faker->addProvider(new Fakecar($faker));


### PR DESCRIPTION
Adds the following cars from [Mahindra](https://www.carwale.com/mahindra-cars/) (India) to the list:

- Alturas G4
- Bolero
- KUV100
- KUV100 NXT
- Marazzo
- Scorpio
- Scorpio Getaway
- TUV300
- TUV300 PLUS
- Thar
- Verito
- Verito Vibe CS
- XUV500
- e20 NXT
- e2o PLUS
- eKUV100
- XUV300

Note that the e2o PLUS and e20 NXT aren't spelling mistakes - they are actually e2o and e20 for some particular reason.

This is a fun package! I love it!