### PR TITLE
vehicleGearBoxType now returns string instead of weighted number

### DIFF
--- a/src/Fakecar.php
+++ b/src/Fakecar.php
@@ -155,7 +155,7 @@ class Fakecar extends \Faker\Provider\Base
      */
     public static function vehicleGearBoxType()
     {
-        return static::randomElement(CarData::getVehicleGearBoxType());
+        return static::getWeighted(CarData::getVehicleGearBoxType());
     }
 
     /**

--- a/tests/Faker/FakecarTest.php
+++ b/tests/Faker/FakecarTest.php
@@ -172,7 +172,7 @@ class FakecarTest extends TestCase
 
     public function testVehicleGearBox()
     {
-        $this->assertTrue(in_array($this->faker->vehicleGearBoxType, CarData::getVehicleGearBoxType()));
+        $this->assertTrue(in_array($this->faker->vehicleGearBoxType, array_keys(CarData::getVehicleGearBoxType())));
     }
 
     public function testGetRandomElementsFromArray()


### PR DESCRIPTION
This resolves the issue I'd added earlier. https://github.com/pelmered/fake-car/issues/8