### PR TITLE
Removes constructor & unused class

### DIFF
--- a/src/Fakecar.php
+++ b/src/Fakecar.php
@@ -2,22 +2,10 @@
 
 namespace Faker\Provider;
 
-use Faker\Generator;
-
 class Fakecar extends \Faker\Provider\Base
 {
     const EBCDIC = "0123456789.ABCDEFGH..JKLMN.P.R..STUVWXYZ";
     const MODELYEAR = "ABCDEFGHJKLMNPRSTVWXY123456789";
-
-    /**
-     * Fakecar constructor.
-     *
-     * @param \Faker\Generator $generator
-     */
-    public function __construct(Generator $generator)
-    {
-        parent::__construct($generator);
-    }
 
     /**
      * Get vehicle string with brand and model


### PR DESCRIPTION
- Constructor can be removed because it's useless as it does the same as the constructor of the parent class. 
- The Faker\Generator class is not used so it's useless & can be removed