### PR TITLE
PHPUnit to 9.3 + makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+TESTS_DIR=./tests/Faker
+VENDOR_DIR=./vendor
+
+PHPUNIT_BIN=./vendor/phpunit/phpunit/phpunit
+PHP_BIN=php
+COMPOSER_BIN=composer
+
+list: 			# Display this list
+	@cat Makefile \
+		| grep "^[a-z0-9_]\+:" \
+		| sed -r "s/:[^#]*?#?(.*)?/\r\t\t\t\t-\1/" \
+		| sed "s/^/ • make /" \
+		| sort
+
+
+install:	# Install dependencies
+	@$(COMPOSER_BIN) install --no-dev 2>&1
+
+install-dev:# Install with dev dependencies
+	@$(COMPOSER_BIN) install 2>&1
+
+update:		# Update dependencies
+	@$(COMPOSER_BIN) update
+
+autoloader:	# Dump autoloader
+	@$(COMPOSER_BIN) dump-autoload
+
+test:		# Run tests
+	@$(PHP_BIN) $(PHPUNIT_BIN) -c $(TESTS_DIR)/phpunit.xml
+
+test-coverage:	# Show codecoverage
+	@$(PHP_BIN) $(PHPUNIT_BIN) --coverage-text  -c $(TESTS_DIR)/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "fzaninotto/faker": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.4",
         "fzaninotto/faker": "^1"
     },
     "require-dev": {

--- a/tests/Faker/FakecarTest.php
+++ b/tests/Faker/FakecarTest.php
@@ -107,8 +107,8 @@ class FakecarTest extends TestCase
 
     public function testVehicleRegistration()
     {
-        $this->assertRegExp('/[A-Z]{3}-[0-9]{3}/', $this->faker->vehicleRegistration());
-        $this->assertRegExp('/[A-Z]{2}-[0-9]{5}/', $this->faker->vehicleRegistration('[A-Z]{2}-[0-9]{5}'));
+        $this->assertMatchesRegularExpression('/[A-Z]{3}-[0-9]{3}/', $this->faker->vehicleRegistration());
+        $this->assertMatchesRegularExpression('/[A-Z]{2}-[0-9]{5}/', $this->faker->vehicleRegistration('[A-Z]{2}-[0-9]{5}'));
     }
 
     public function testVehicleType()

--- a/tests/Faker/phpunit.xml
+++ b/tests/Faker/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="../../vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">../../src</directory>
+        </include>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
- Updated phpunit to 9.3 and php to 7.4.
- Added a makefile to install dependencies, run updates and tests. Simple type "make" to see the list with options.
- Fixed a deprecated  test